### PR TITLE
Создание ресурсов без глобальной роли

### DIFF
--- a/lib/ya_acl/builder.rb
+++ b/lib/ya_acl/builder.rb
@@ -35,7 +35,8 @@ module YaAcl
 
     def resource(name, allow_roles = [], &block)
       raise ArgumentError, 'Options "allow_roles" must be Array' unless allow_roles.is_a? Array
-      resource_allow_roles = allow_roles << @global_allow_role
+      resource_allow_roles = allow_roles
+      resource_allow_roles << @global_allow_role if @global_allow_role
       resource = Resource.new(name)
       acl.add_resource resource
       PrivilegeProxy.new(resource.name, resource_allow_roles, acl, block)

--- a/spec/ya_acl/builder_spec.rb
+++ b/spec/ya_acl/builder_spec.rb
@@ -42,7 +42,7 @@ describe YaAcl::Builder do
         end
       end
     end
-    
+
     acl.check!(:name, :index, [:admin]).should be_true
     acl.check!(:name, :index, [:another_admin]).should be_true
     acl.check!(:name, :index, [:operator]).should be_true
@@ -142,5 +142,19 @@ describe YaAcl::Builder do
     acl.allow?(:name, :update, [:operator], :first => true, :second => true).should be_false
     acl.allow?(:name, :update, [:operator], :first => 1, :second => 1).should be_true
     acl.allow?(:name, :update, [:operator], :first => 3, :second => 3).should be_false
+  end
+
+  it 'should be work without global role' do
+    acl = YaAcl::Builder.build do
+      roles do
+        role :admin
+      end
+
+      resource :name, [:admin] do
+        privilege :index
+      end
+    end
+
+    acl.check!(:name, :index, [:admin]).should be_true
   end
 end


### PR DESCRIPTION
Хочется иметь возможность сделать ресурсы которые будут не доступны глобальной роли. К примеру:

``` ruby
YaAcl::Builder.build do
  roles do
    role :admin,    :name => 'Администратор'
  end

  resource 'Devise::SessionsController', [:guest] do
    privilege :new
    privilege :create
  end
end
```

Потому как если у тебя уже есть роль admin значит ты залогинен и создать сессию еще раз тебя не положено.
